### PR TITLE
Require transient activation to use API

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,6 +636,9 @@
               </li>
             </ol>
           </li>
+          <li>[=Consume user activation=] of [=this=]'s [=relevant global
+          object=].
+          </li>
           <li>[=In parallel=], [=request a position=] passing
           |successCallback|, |errorCallback|, and |options|.
           </li>
@@ -671,6 +674,9 @@
               <li>Return 0.
               </li>
             </ol>
+          </li>
+          <li>[=Consume user activation=] of [=this=]'s [=relevant global
+          object=].
           </li>
           <li>Let |watchId:unsigned long| be an [=implementation-defined=]
           {{unsigned long}} that is greater than zero.

--- a/index.html
+++ b/index.html
@@ -626,6 +626,16 @@
               </li>
             </ol>
           </li>
+          <li>If [=this=]'s [=relevant global object=] does not have
+          [=transient activation=]:
+            <ol>
+              <li>[=Call back with error=] |errorCallback| and
+              {{GeolocationPositionError/PERMISSION_DENIED}}.
+              </li>
+              <li>Terminate this algorithm.
+              </li>
+            </ol>
+          </li>
           <li>[=In parallel=], [=request a position=] passing
           |successCallback|, |errorCallback|, and |options|.
           </li>
@@ -647,6 +657,16 @@
             <ol>
               <li>[=Call back with error=] passing |errorCallback| and
               {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
+              </li>
+              <li>Return 0.
+              </li>
+            </ol>
+          </li>
+          <li>If [=this=]'s [=relevant global object=] does not have
+          [=transient activation=]:
+            <ol>
+              <li>[=Call back with error=] |errorCallback| and
+              {{GeolocationPositionError/PERMISSION_DENIED}}.
               </li>
               <li>Return 0.
               </li>


### PR DESCRIPTION
Closes #48 

To kick off discussion - **this would break most sites**, so this change would be a multi-year change potentially. 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=228017)
 * [ ] [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1102381) 
 * [ ] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1720832)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/94.html" title="Last updated on Aug 5, 2021, 12:17 AM UTC (f3210fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/94/2c0c516...f3210fd.html" title="Last updated on Aug 5, 2021, 12:17 AM UTC (f3210fd)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/94.html" title="Last updated on Feb 21, 2022, 11:42 PM UTC (8d0249c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/94/84d08c3...8d0249c.html" title="Last updated on Feb 21, 2022, 11:42 PM UTC (8d0249c)">Diff</a>