### PR TITLE
Correction: Update acquisition algorithm to define data types and handle cached positions

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,8 +849,8 @@
                         than |cacheTime|, and
                         |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
                         equals
-                        |options|.{{PositionOptions/enableHighAccuracy}}<del cite="#c8">, set
-                        |position| to |cachedPosition|.</del> <ins cite=
+                        |options|.{{PositionOptions/enableHighAccuracy}}<del cite="#c8">,
+                        set |position| to |cachedPosition|.</del> <ins cite=
                         "#c8">:
                         <ol>
                           <li>[=Queue a task=] on the [=geolocation task
@@ -894,43 +894,74 @@
                       enhancements to attribute accuracy and clarity.
                     </aside><ins cite="#c9">
                     <ol data-cite="infra">
-                      <li>Let |positionData| be a [=map=] that will hold the
-                      acquired position data.
+                      <li>Let |positionData| be a [=map=] with the following
+                      name/value pairs based on the acquired the position data:
+                        <dl>
+                          <dd>
+                            <dl>
+                              <dt>
+                                "longitude"
+                              </dt>
+                              <dd>
+                                A {{double}} that represents the longitude
+                                coordinates on the Earth's surface in degrees,
+                                using the [[WGS84]] coordinate system.
+                                Longitude measures how far east or west a point
+                                is from the Prime Meridian.
+                              </dd>
+                              <dt>
+                                "altitude"
+                              </dt>
+                              <dd>
+                                A {{double?}} that represents the altitude in
+                                meters above the [[WGS84]] ellipsoid, or `null`
+                                if not available. Altitude measures the height
+                                above sea level.
+                              </dd>
+                              <dt>
+                                "accuracy"
+                              </dt>
+                              <dd>
+                                A non-negative {{double}} that represents the
+                                accuracy value indicating the 95% confidence
+                                level in meters. Accuracy measures how close
+                                the measured coordinates are to the true
+                                position.
+                              </dd>
+                              <dt>
+                                "altitudeAccuracy"
+                              </dt>
+                              <dd>
+                                A non-negative {{double?}} that represents the
+                                altitude accuracy, or `null` if not available,
+                                indicating the 95% confidence level in meters.
+                                Altitude accuracy measures how close the
+                                measured altitude is to the true altitude.
+                              </dd>
+                              <dt>
+                                "speed"
+                              </dt>
+                              <dd>
+                                A non-negative {{double?}} that represents the
+                                speed in meters per second, or `null` if not
+                                available. Speed measures how fast the device
+                                is moving.
+                              </dd>
+                              <dt>
+                                "heading"
+                              </dt>
+                              <dd>
+                                A {{double?}} that represents the heading in
+                                degrees, or `null` if not available, or `NaN`
+                                if the device is stationary. Heading measures
+                                the direction in which the device is moving
+                                relative to true north.
+                              </dd>
+                            </dl>
+                          </dd>
+                        </dl>
                       </li>
-                      <li>Set |positionData|["longitude"] to represent the
-                      longitude coordinates on the Earth's surface as a
-                      {{double}} in degrees, using the [[WGS84]] coordinate
-                      system. Longitude measures how far east or west a point
-                      is from the Prime Meridian.
-                      </li>
-                      <li>Set |positionData|["altitude"] to represent the
-                      altitude as a {{double?}} in meters above the [[WGS84]]
-                      ellipsoid or `null` if not available. Altitude measures
-                      the height above sea level.
-                      </li>
-                      <li>Set |positionData|["accuracy"] to represent the
-                      accuracy as a non-negative {{double}} indicating the 95%
-                      confidence level in meters. Accuracy measures how close
-                      the measured coordinates are to the true position.
-                      </li>
-                      <li>Set |positionData|["altitudeAccuracy"] to represent
-                      the altitude accuracy as a non-negative {{double?}} or
-                      `null` if not available, indicating the 95% confidence
-                      level in meters. Altitude accuracy measures how close the
-                      measured altitude is to the true altitude.
-                      </li>
-                      <li>Set |positionData|["speed"] to represent the speed as
-                      a non-negative {{double?}} in meters per second or `null`
-                      if not available. Speed measures how fast the device is
-                      moving.
-                      </li>
-                      <li>Set |positionData|["heading"] to represent the
-                      heading as a {{double?}} in degrees or `null` if not
-                      available. If the device is stationary, set to NaN.
-                      Heading measures the direction in which the device is
-                      moving relative to true north.
-                      </li>
-                      <li>Set |position| be [=a new `GeolocationPosition`=]
+                      <li>Set |position| to [=a new `GeolocationPosition`=]
                       passing |positionData|, |acquisitionTime| and
                       |options|.{{PositionOptions/enableHighAccuracy}}.
                       </li>
@@ -939,7 +970,7 @@
                       </li>
                     </ol></ins> <del>
                     <ol>
-                      <li>Set |position| be [=a new `GeolocationPosition`=]
+                      <li>Set |position| to [=a new `GeolocationPosition`=]
                       passing |acquisitionTime| and
                       |options|.{{PositionOptions/enableHighAccuracy}}.
                       </li>
@@ -1278,8 +1309,8 @@
         <aside class="correction" id="c4">
           <span class="marker">Candidate Correction:</span> Constructor now
           takes a [=map=] of position data, a timestamp, and a boolean
-          indicating high accuracy as arguments. We iterate over the map to
-          set the attributes of the {{GeolocationCoordinates}}.
+          indicating high accuracy as arguments. We iterate over the map to set
+          the attributes of the {{GeolocationCoordinates}}.
         </aside>
         <p>
           <dfn>A new `GeolocationPosition`</dfn> is constructed with [=map=]

--- a/index.html
+++ b/index.html
@@ -838,27 +838,29 @@
                       value of the |options|.{{PositionOptions/maximumAge}}
                       member.
                       </li>
-                      <li>If
-                      |cachedPosition|.{{GeolocationPosition/timestamp}}'s
-                      value is greater than |cacheTime|, and
-                      |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
-                      equals |options|.{{PositionOptions/enableHighAccuracy}}:
-                        <div class="correction" id="c8">
+                      <li>
+                        <aside class="correction" id="c8">
                           <span class="marker">Candidate Correction:</span>
                           Updated to ensure that the algorithm terminates
                           immediately if a valid cached position is used,
                           avoiding unnecessary steps.
-                          <ol>
-                            <li>
-                              <ins>[=Queue a task=] on the [=geolocation task
-                              source=] with a step that [=invokes=]
-                              |successCallback| with |cachedPosition|.</ins>
-                            </li>
-                            <li>
-                              <ins>Terminate this algorithm.</ins>
-                            </li>
-                          </ol>
-                        </div>
+                        </aside>If |cachedPosition|'s
+                        {{GeolocationPosition/timestamp}}'s value is greater
+                        than |cacheTime|, and
+                        |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
+                        <del cite="#c8">equals
+                        |options|.{{PositionOptions/enableHighAccuracy}}, set
+                        |position| to |cachedPosition|.</del> <ins cite=
+                        "#c8">equals
+                        |options|.{{PositionOptions/enableHighAccuracy}}:
+                        <ol>
+                          <li>[=Queue a task=] on the [=geolocation task
+                          source=] with a step that [=invokes=]
+                          |successCallback| with |cachedPosition|.
+                          </li>
+                          <li>Terminate this algorithm.
+                          </li>
+                        </ol></ins>
                       </li>
                     </ol>
                   </li>
@@ -881,69 +883,70 @@
                     </ol>
                   </li>
                   <li>If acquiring the position data from the system succeeds:
-                    <ol>
-                      <li>
-                        <div class="correction" id="c5">
-                          <span class="marker">Candidate Correction:</span>
-                          Each acquired data type is now explicitly defined
-                          with units and standards.
-                          <ol>
-                            <li>
-                              <ins>Let |latitude:double| be a real number of
-                              degrees, in the [[WGS84]] coordinate
-                              system.</ins>
-                            </li>
-                            <li>
-                              <ins>Let |longitude:double| be a real number of
-                              degrees, in the [[WGS84]] coordinate
-                              system.</ins>
-                            </li>
-                            <li>
-                              <ins>Let |altitude:double?| be a height, in
-                              meters, above the [[WGS84]] ellipsoid or `null`
-                              if not available.</ins>
-                            </li>
-                            <li>
-                              <ins>Let |accuracy:double| be a non-negative real
-                              number representing a 95% confidence level.</ins>
-                            </li>
-                            <li>
-                              <ins>Let |altitudeAccuracy:double?| be a
-                              non-negative real number or `null` if not
-                              available, representing a 95% confidence
-                              level.</ins>
-                            </li>
-                            <li>
-                              <ins>Let |speed:double?| be a non-negative real
-                              number of meters per second or `null` if not
-                              available.</ins>
-                            </li>
-                            <li>
-                              <ins>Let |heading:double?| be a real number of
-                              degrees or `null` if not available. If the device
-                              is stationary, set to NaN.</ins>
-                            </li>
-                          </ol>
-                        </div>
+                    <aside class="correction" id="c9">
+                      <span class="marker">Candidate Correction:</span> We now
+                      use a [=map=] to represent the position data. Clarified
+                      the units and reference systems for latitude, longitude,
+                      and altitude, ensuring consistency with the updated
+                      attribute definitions. Updated to the descriptions of the
+                      speed and heading to specify measurement units and
+                      conditions for null values, aligning with the overall
+                      enhancements to attribute accuracy and clarity.
+                    </aside><ins cite="#c9">
+                    <ol data-cite="infra">
+                      <li>Let |positionData| be a [=map=] that will hold the
+                      acquired position data.
                       </li>
-                      <li>
-                        <div class="correction" id="c6">
-                          <span class="marker">Candidate Correction:</span>
-                          Updated the parameters passed to the
-                          `GeolocationPosition` constructor to align with the
-                          new data specifications.
-                          Set |position| to be [=a new
-                          `GeolocationPosition`=] passing <ins>|latitude|,
-                          |longitude|, |altitude|, |accuracy|,
-                          |altitudeAccuracy|, |speed|, |heading|, </ins>
-                          |acquisitionTime|, and
-                          |options|.{{PositionOptions/enableHighAccuracy}}.
-                        </div>
+                      <li>Set |positionData|["longitude"] to represent the
+                      longitude coordinates on the Earth's surface as a
+                      {{double}} in degrees, using the [[WGS84]] coordinate
+                      system. Longitude measures how far east or west a point
+                      is from the Prime Meridian.
+                      </li>
+                      <li>Set |positionData|["altitude"] to represent the
+                      altitude as a {{double?}} in meters above the [[WGS84]]
+                      ellipsoid or `null` if not available. Altitude measures
+                      the height above sea level.
+                      </li>
+                      <li>Set |positionData|["accuracy"] to represent the
+                      accuracy as a non-negative {{double}} indicating the 95%
+                      confidence level in meters. Accuracy measures how close
+                      the measured coordinates are to the true position.
+                      </li>
+                      <li>Set |positionData|["altitudeAccuracy"] to represent
+                      the altitude accuracy as a non-negative {{double?}} or
+                      `null` if not available, indicating the 95% confidence
+                      level in meters. Altitude accuracy measures how close the
+                      measured altitude is to the true altitude.
+                      </li>
+                      <li>Set |positionData|["speed"] to represent the speed as
+                      a non-negative {{double?}} in meters per second or `null`
+                      if not available. Speed measures how fast the device is
+                      moving.
+                      </li>
+                      <li>Set |positionData|["heading"] to represent the
+                      heading as a {{double?}} in degrees or `null` if not
+                      available. If the device is stationary, set to NaN.
+                      Heading measures the direction in which the device is
+                      moving relative to true north.
+                      </li>
+                      <li>Set |position| be [=a new `GeolocationPosition`=]
+                      passing |positionData|, |acquisitionTime| and
+                      |options|.{{PositionOptions/enableHighAccuracy}}.
                       </li>
                       <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
                       |position|.
                       </li>
-                    </ol>
+                    </ol></ins> <del>
+                    <ol>
+                      <li>Set |position| be [=a new `GeolocationPosition`=]
+                      passing |acquisitionTime| and
+                      |options|.{{PositionOptions/enableHighAccuracy}}.
+                      </li>
+                      <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
+                      |position|.
+                      </li>
+                    </ol></del>
                   </li>
                   <li>Stop the |timeout|.
                   </li>
@@ -1272,69 +1275,26 @@
         <h2>
           Constructing a `GeolocationPosition`
         </h2>
-        <aside class="correction" id="c7">
-          <span class="marker">Candidate Correction:</span> Updated the
-          constructor parameters to include explicit data types and conditions
-          as defined in the IDL, enhancing the clarity and precision of the
-          specification.
+        <aside class="correction" id="c4">
+          <span class="marker">Candidate Correction:</span> Constructor now
+          takes a [=map=] of position data, a timestamp, and a boolean
+          indicating high accuracy as arguments. We itereate over the map to
+          set the attributes of the {{GeolocationCoordinates}}.
         </aside>
         <p>
-          <dfn>A new `GeolocationPosition`</dfn> is constructed with a <ins>{{double}} |latitude:double|,
-            {{double}} |longitude:double|, {{double?}} |altitude:double?|,
-            {{double}} |accuracy:double|, {{double?}}
-            |altitudeAccuracy:double?|, {{double?}} |speed:double?|,
-            {{double?}} |heading:double?|, {{EpochTimeStamp}}
-            |timestamp:EpochTimeStamp|, {{boolean}}
-            |isHighAccuracy:boolean|</ins> by performing the following steps:
-        </p>
+          <dfn>A new `GeolocationPosition`</dfn> is constructed with [=map=]
+          |positionData|, {{EpochTimeStamp}} |timestamp:EpochTimeStamp| and
+          boolean |isHighAccuracy| by performing the following steps:
+        </p><ins cite="#c4">
         <ol class="algorithm">
           <li>Let |coords:GeolocationCoordinates| be a newly created
-          {{GeolocationCoordinates}} instance:
-            <div class="correction" id="c4">
-              <span class="marker">Candidate Correction:</span> Enhanced the
-              constructor steps for {{GeolocationCoordinates}} to take
-              arguments from call site.
-              <ol>
-                <li>Initialize |coord|'s {{GeolocationCoordinates/latitude}}
-                attribute to <del>a geographic coordinate in decimal
-                degrees.</del> <ins>|latitude|.</ins>
-                </li>
-                <li>Initialize |coord|'s {{GeolocationCoordinates/longitude}}
-                attribute to <del>a geographic coordinate in decimal
-                degrees.</del> <ins>|longitude|.</ins>
-                </li>
-                <li>Initialize |coord|'s {{GeolocationCoordinates/altitude}}
-                <del>attribute in meters above the [[WGS84]] ellipsoid, or
-                `null` if the implementation cannot provide altitude
-                information.</del> <ins>attribute to |altitude|.</ins>
-                </li>
-                <li>Initialize |coord|'s {{GeolocationCoordinates/speed}}
-                attribute to <del>a non-negative real number, or as `null` if
-                the implementation cannot provide speed information.</del>
-                <ins>|speed|.</ins>
-                </li>
-                <li>Initialize |coord|'s {{GeolocationCoordinates/heading}}
-                <del>attribute in degrees, or `null` if the implementation
-                cannot provide heading information. If the hosting device is
-                stationary (i.e., the value of the
-                {{GeolocationCoordinates/speed}} attribute is 0), then
-                initialize the {{GeolocationCoordinates/heading}} to
-                `NaN`.</del> <ins>attribute to |heading|.</ins>
-                </li>
-                <li>Initialize |coord|'s {{GeolocationCoordinates/accuracy}}
-                attribute to <del>a non-negative real number. The value SHOULD
-                correspond to a 95% confidence level with respect to the
-                longitude and latitude values.</del> <ins>|accuracy|.</ins>
-                </li>
-                <li>Initialize |coord|'s
-                {{GeolocationCoordinates/altitudeAccuracy}} attribute <del>as
-                non-negative real number, or to `null` if the implementation
-                cannot provide altitude information. If the altitude accuracy
-                information is provided, it SHOULD correspond to a 95%
-                confidence level.</del> <ins>to |altitudeAccuracy|.</ins>
-                </li>
-              </ol>
-            </div>
+          {{GeolocationCoordinates}} instance
+          </li>
+          <li>[=map/For Each=] |key| in |positionData|:
+            <ol>
+              <li>Set |coords|'s |key| attribute to |positionData|[|key|].
+              </li>
+            </ol>
           </li>
           <li>Return a newly created {{GeolocationPosition}} instance with its
           {{GeolocationPosition/coords}} attribute initialized to |coords| and
@@ -1342,7 +1302,58 @@
           |timestamp|, and its {{GeolocationPosition/[[isHighAccuracy]]}}
           internal slot set to |isHighAccuracy|.
           </li>
-        </ol>
+        </ol></ins> <del cite="#c4">
+        <p>
+          <dfn>A new `GeolocationPosition`</dfn> is constructed with
+          {{EpochTimeStamp}} |timestamp:EpochTimeStamp| and boolean
+          |isHighAccuracy| by performing the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let |coords:GeolocationCoordinates| be a newly created
+          {{GeolocationCoordinates}} instance:
+            <ol>
+              <li>Initialize |coord|'s {{GeolocationCoordinates/latitude}}
+              attribute to a geographic coordinate in decimal degrees.
+              </li>
+              <li>Initialize |coord|'s {{GeolocationCoordinates/longitude}}
+              attribute to a geographic coordinate in decimal degrees.
+              </li>
+              <li>Initialize |coord|'s {{GeolocationCoordinates/accuracy}}
+              attribute to a non-negative real number. The value SHOULD
+              correspond to a 95% confidence level with respect to the
+              longitude and latitude values.
+              </li>
+              <li>Initialize |coord|'s {{GeolocationCoordinates/altitude}}
+              attribute in meters above the [[WGS84]] ellipsoid, or `null` if
+              the implementation cannot provide altitude information.
+              </li>
+              <li>Initialize |coord|'s
+              {{GeolocationCoordinates/altitudeAccuracy}} attribute as
+              non-negative real number, or to `null` if the implementation
+              cannot provide altitude information. If the altitude accuracy
+              information is provided, it SHOULD correspond to a 95% confidence
+              level.
+              </li>
+              <li>Initialize |coord|'s {{GeolocationCoordinates/speed}}
+              attribute to a non-negative real number, or as `null` if the
+              implementation cannot provide speed information.
+              </li>
+              <li>Initialize |coord|'s {{GeolocationCoordinates/heading}}
+              attribute in degrees, or `null` if the implementation cannot
+              provide heading information. If the hosting device is stationary
+              (i.e., the value of the {{GeolocationCoordinates/speed}}
+              attribute is 0), then initialize the
+              {{GeolocationCoordinates/heading}} to `NaN`.
+              </li>
+            </ol>
+          </li>
+          <li>Return a newly created {{GeolocationPosition}} instance with its
+          {{GeolocationPosition/coords}} attribute initialized to |coords| and
+          {{GeolocationPosition/timestamp}} attribute initialized to
+          |timestamp|, and its {{GeolocationPosition/[[isHighAccuracy]]}}
+          internal slot set to |isHighAccuracy|.
+          </li>
+        </ol></del>
       </section>
     </section>
     <section id="position_error_interface" data-dfn-for=

--- a/index.html
+++ b/index.html
@@ -882,7 +882,8 @@
                       </li>
                     </ol>
                   </li>
-                  <li>If acquiring the position data from the system succeeds:
+                  <li data-cite="infra">If acquiring the position data from the
+                  system succeeds:
                     <aside class="correction" id="c9">
                       <span class="marker">Candidate Correction:</span> We now
                       use a [=map=] to represent the position data. Clarified
@@ -1271,7 +1272,7 @@
           representation of the {{GeolocationCoordinates}} object.</ins>
         </p>
       </section>
-      <section>
+      <section data-cite="infra">
         <h2>
           Constructing a `GeolocationPosition`
         </h2>
@@ -1288,11 +1289,11 @@
         </p><ins cite="#c4">
         <ol class="algorithm">
           <li>Let |coords:GeolocationCoordinates| be a newly created
-          {{GeolocationCoordinates}} instance
+          {{GeolocationCoordinates}} instance.
           </li>
-          <li>[=map/For Each=] |key| in |positionData|:
+          <li>[=map/For Each=] |key| → |value| in |positionData|:
             <ol>
-              <li>Set |coords|'s |key| attribute to |positionData|[|key|].
+              <li>Set |coords|'s attribute named |key| to |value|.
               </li>
             </ol>
           </li>
@@ -1304,7 +1305,7 @@
           </li>
         </ol></ins> <del cite="#c4">
         <p>
-          <dfn>A new `GeolocationPosition`</dfn> is constructed with
+          <strong>A new `GeolocationPosition`</strong> is constructed with
           {{EpochTimeStamp}} |timestamp:EpochTimeStamp| and boolean
           |isHighAccuracy| by performing the following steps:
         </p>

--- a/index.html
+++ b/index.html
@@ -848,11 +848,10 @@
                         {{GeolocationPosition/timestamp}}'s value is greater
                         than |cacheTime|, and
                         |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
-                        <del cite="#c8">equals
-                        |options|.{{PositionOptions/enableHighAccuracy}}, set
+                        equals
+                        |options|.{{PositionOptions/enableHighAccuracy}}<del cite="#c8">, set
                         |position| to |cachedPosition|.</del> <ins cite=
-                        "#c8">equals
-                        |options|.{{PositionOptions/enableHighAccuracy}}:
+                        "#c8">:
                         <ol>
                           <li>[=Queue a task=] on the [=geolocation task
                           source=] with a step that [=invokes=]

--- a/index.html
+++ b/index.html
@@ -895,7 +895,7 @@
                     </aside><ins cite="#c9">
                     <ol data-cite="infra">
                       <li>Let |positionData| be a [=map=] with the following
-                      name/value pairs based on the acquired the position data:
+                      name/value pairs based on the acquired position data:
                         <dl>
                           <dt>
                             "longitude"
@@ -1307,16 +1307,16 @@
           indicating high accuracy as arguments. We iterate over the map to set
           the attributes of the {{GeolocationCoordinates}}.
         </aside>
-        <p>
+        <ins cite="#c4"><p>
           <dfn>A new `GeolocationPosition`</dfn> is constructed with [=map=]
           |positionData|, {{EpochTimeStamp}} |timestamp:EpochTimeStamp| and
           boolean |isHighAccuracy| by performing the following steps:
-        </p><ins cite="#c4">
+        </p>
         <ol class="algorithm">
           <li>Let |coords:GeolocationCoordinates| be a newly created
           {{GeolocationCoordinates}} instance.
           </li>
-          <li>[=map/For Each=] |key| → |value| in |positionData|:
+          <li>[=map/For each=] |key| → |value| in |positionData|:
             <ol>
               <li>Set |coords|'s attribute named |key| to |value|.
               </li>

--- a/index.html
+++ b/index.html
@@ -897,67 +897,62 @@
                       <li>Let |positionData| be a [=map=] with the following
                       name/value pairs based on the acquired the position data:
                         <dl>
+                          <dt>
+                            "longitude"
+                          </dt>
                           <dd>
-                            <dl>
-                              <dt>
-                                "longitude"
-                              </dt>
-                              <dd>
-                                A {{double}} that represents the longitude
-                                coordinates on the Earth's surface in degrees,
-                                using the [[WGS84]] coordinate system.
-                                Longitude measures how far east or west a point
-                                is from the Prime Meridian.
-                              </dd>
-                              <dt>
-                                "altitude"
-                              </dt>
-                              <dd>
-                                A {{double?}} that represents the altitude in
-                                meters above the [[WGS84]] ellipsoid, or `null`
-                                if not available. Altitude measures the height
-                                above sea level.
-                              </dd>
-                              <dt>
-                                "accuracy"
-                              </dt>
-                              <dd>
-                                A non-negative {{double}} that represents the
-                                accuracy value indicating the 95% confidence
-                                level in meters. Accuracy measures how close
-                                the measured coordinates are to the true
-                                position.
-                              </dd>
-                              <dt>
-                                "altitudeAccuracy"
-                              </dt>
-                              <dd>
-                                A non-negative {{double?}} that represents the
-                                altitude accuracy, or `null` if not available,
-                                indicating the 95% confidence level in meters.
-                                Altitude accuracy measures how close the
-                                measured altitude is to the true altitude.
-                              </dd>
-                              <dt>
-                                "speed"
-                              </dt>
-                              <dd>
-                                A non-negative {{double?}} that represents the
-                                speed in meters per second, or `null` if not
-                                available. Speed measures how fast the device
-                                is moving.
-                              </dd>
-                              <dt>
-                                "heading"
-                              </dt>
-                              <dd>
-                                A {{double?}} that represents the heading in
-                                degrees, or `null` if not available, or `NaN`
-                                if the device is stationary. Heading measures
-                                the direction in which the device is moving
-                                relative to true north.
-                              </dd>
-                            </dl>
+                            A {{double}} that represents the longitude
+                            coordinates on the Earth's surface in degrees,
+                            using the [[WGS84]] coordinate system. Longitude
+                            measures how far east or west a point is from the
+                            Prime Meridian.
+                          </dd>
+                          <dt>
+                            "altitude"
+                          </dt>
+                          <dd>
+                            A {{double?}} that represents the altitude in
+                            meters above the [[WGS84]] ellipsoid, or `null` if
+                            not available. Altitude measures the height above
+                            sea level.
+                          </dd>
+                          <dt>
+                            "accuracy"
+                          </dt>
+                          <dd>
+                            A non-negative {{double}} that represents the
+                            accuracy value indicating the 95% confidence level
+                            in meters. Accuracy measures how close the measured
+                            coordinates are to the true position.
+                          </dd>
+                          <dt>
+                            "altitudeAccuracy"
+                          </dt>
+                          <dd>
+                            A non-negative {{double?}} that represents the
+                            altitude accuracy, or `null` if not available,
+                            indicating the 95% confidence level in meters.
+                            Altitude accuracy measures how close the measured
+                            altitude is to the true altitude.
+                          </dd>
+                          <dt>
+                            "speed"
+                          </dt>
+                          <dd>
+                            A non-negative {{double?}} that represents the
+                            speed in meters per second, or `null` if not
+                            available. Speed measures how fast the device is
+                            moving.
+                          </dd>
+                          <dt>
+                            "heading"
+                          </dt>
+                          <dd>
+                            A {{double?}} that represents the heading in
+                            degrees, or `null` if not available, or `NaN` if
+                            the device is stationary. Heading measures the
+                            direction in which the device is moving relative to
+                            true north.
                           </dd>
                         </dl>
                       </li>

--- a/index.html
+++ b/index.html
@@ -889,7 +889,7 @@
                       use a [=map=] to represent the position data. Clarified
                       the units and reference systems for latitude, longitude,
                       and altitude, ensuring consistency with the updated
-                      attribute definitions. Updated to the descriptions of the
+                      attribute definitions. Updated the descriptions of the
                       speed and heading to specify measurement units and
                       conditions for null values, aligning with the overall
                       enhancements to attribute accuracy and clarity.

--- a/index.html
+++ b/index.html
@@ -1278,7 +1278,7 @@
         <aside class="correction" id="c4">
           <span class="marker">Candidate Correction:</span> Constructor now
           takes a [=map=] of position data, a timestamp, and a boolean
-          indicating high accuracy as arguments. We itereate over the map to
+          indicating high accuracy as arguments. We iterate over the map to
           set the attributes of the {{GeolocationCoordinates}}.
         </aside>
         <p>

--- a/index.html
+++ b/index.html
@@ -838,12 +838,27 @@
                       value of the |options|.{{PositionOptions/maximumAge}}
                       member.
                       </li>
-                      <li>If |cachedPosition|'s
-                      {{GeolocationPosition/timestamp}}'s value is greater than
-                      |cacheTime|, and
+                      <li>If
+                      |cachedPosition|.{{GeolocationPosition/timestamp}}'s
+                      value is greater than |cacheTime|, and
                       |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
-                      equals |options|.{{PositionOptions/enableHighAccuracy}},
-                      set |position| to |cachedPosition|.
+                      equals |options|.{{PositionOptions/enableHighAccuracy}}:
+                        <div class="correction" id="c8">
+                          <span class="marker">Candidate Correction:</span>
+                          Updated to ensure that the algorithm terminates
+                          immediately if a valid cached position is used,
+                          avoiding unnecessary steps.
+                          <ol>
+                            <li>
+                              <ins>[=Queue a task=] on the [=geolocation task
+                              source=] with a step that [=invokes=]
+                              |successCallback| with |cachedPosition|.</ins>
+                            </li>
+                            <li>
+                              <ins>Terminate this algorithm.</ins>
+                            </li>
+                          </ol>
+                        </div>
                       </li>
                     </ol>
                   </li>
@@ -867,9 +882,63 @@
                   </li>
                   <li>If acquiring the position data from the system succeeds:
                     <ol>
-                      <li>Set |position| be [=a new `GeolocationPosition`=]
-                      passing |acquisitionTime| and
-                      |options|.{{PositionOptions/enableHighAccuracy}}.
+                      <li>
+                        <div class="correction" id="c5">
+                          <span class="marker">Candidate Correction:</span>
+                          Each acquired data type is now explicitly defined
+                          with units and standards.
+                          <ol>
+                            <li>
+                              <ins>Let |latitude:double| be a real number of
+                              degrees, in the [[WGS84]] coordinate
+                              system.</ins>
+                            </li>
+                            <li>
+                              <ins>Let |longitude:double| be a real number of
+                              degrees, in the [[WGS84]] coordinate
+                              system.</ins>
+                            </li>
+                            <li>
+                              <ins>Let |altitude:double?| be a height, in
+                              meters, above the [[WGS84]] ellipsoid or `null`
+                              if not available.</ins>
+                            </li>
+                            <li>
+                              <ins>Let |accuracy:double| be a non-negative real
+                              number representing a 95% confidence level.</ins>
+                            </li>
+                            <li>
+                              <ins>Let |altitudeAccuracy:double?| be a
+                              non-negative real number or `null` if not
+                              available, representing a 95% confidence
+                              level.</ins>
+                            </li>
+                            <li>
+                              <ins>Let |speed:double?| be a non-negative real
+                              number of meters per second or `null` if not
+                              available.</ins>
+                            </li>
+                            <li>
+                              <ins>Let |heading:double?| be a real number of
+                              degrees or `null` if not available. If the device
+                              is stationary, set to NaN.</ins>
+                            </li>
+                          </ol>
+                        </div>
+                      </li>
+                      <li>
+                        <div class="correction" id="c6">
+                          <span class="marker">Candidate Correction:</span>
+                          Updated the parameters passed to the
+                          `GeolocationPosition` constructor to align with the
+                          new data specifications.
+                          Set |position| to be [=a new
+                          `GeolocationPosition`=] passing <ins>|latitude|,
+                          |longitude|, |altitude|, |accuracy|,
+                          |altitudeAccuracy|, |speed|, |heading|, </ins>
+                          |acquisitionTime|, and
+                          |options|.{{PositionOptions/enableHighAccuracy}}.
+                        </div>
                       </li>
                       <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
                       |position|.
@@ -1203,79 +1272,69 @@
         <h2>
           Constructing a `GeolocationPosition`
         </h2>
+        <aside class="correction" id="c7">
+          <span class="marker">Candidate Correction:</span> Updated the
+          constructor parameters to include explicit data types and conditions
+          as defined in the IDL, enhancing the clarity and precision of the
+          specification.
+        </aside>
         <p>
-          <dfn>A new `GeolocationPosition`</dfn> is constructed with
-          {{EpochTimeStamp}} |timestamp:EpochTimeStamp| and boolean
-          |isHighAccuracy| by performing the following steps:
+          <dfn>A new `GeolocationPosition`</dfn> is constructed with a <ins>{{double}} |latitude:double|,
+            {{double}} |longitude:double|, {{double?}} |altitude:double?|,
+            {{double}} |accuracy:double|, {{double?}}
+            |altitudeAccuracy:double?|, {{double?}} |speed:double?|,
+            {{double?}} |heading:double?|, {{EpochTimeStamp}}
+            |timestamp:EpochTimeStamp|, {{boolean}}
+            |isHighAccuracy:boolean|</ins> by performing the following steps:
         </p>
-        <aside class="correction" id="c4">
-          <span class="marker">Candidate Correction:</span> Enhanced the
-          constructor steps for {{GeolocationCoordinates}} to clarify the units
-          and reference systems for latitude, longitude, and altitude, ensuring
-          consistency with the updated attribute definitions.
-        </aside>
-        <aside class="correction" id="c5">
-          <span class="marker">Candidate Correction:</span> Updates to the
-          descriptions of the speed and heading attributes to specify
-          measurement units and conditions for null values, aligning with the
-          overall enhancements to attribute accuracy and clarity.
-        </aside>
         <ol class="algorithm">
           <li>Let |coords:GeolocationCoordinates| be a newly created
           {{GeolocationCoordinates}} instance:
-            <ol>
-              <li>Initialize |coord|'s {{GeolocationCoordinates/latitude}}
-              <del cite="#c4">attribute to a geographic coordinate in decimal
-              degrees.</del> <ins cite="#c4">attribute to a latitude, specified
-              as a real number of degrees, in the [[WGS84]] coordinate
-              system.</ins>
-              </li>
-              <li>Initialize |coord|'s {{GeolocationCoordinates/longitude}}
-              <del cite="#c4">attribute to a geographic coordinate in decimal
-              degrees.</del> <ins cite="#c4">attribute to a longitude,
-              specified as a real number of degrees, in the [[WGS84]]
-              coordinate system.</ins>
-              </li>
-              <li>Initialize |coord|'s {{GeolocationCoordinates/altitude}}
-              <del cite="#c4">attribute in meters above the [[WGS84]]
-              ellipsoid, or `null` if the implementation cannot provide
-              altitude information.</del> <ins cite="#c4">attribute to a
-              height, in meters, above the [[WGS84]] ellipsoid, or `null` if
-              the implementation cannot provide altitude information.</ins>
-              </li>
-              <li>Initialize |coord|'s {{GeolocationCoordinates/speed}}
-              <del cite="#c5">attribute to a non-negative real number, or as
-              `null` if the implementation cannot provide speed
-              information.</del> <ins cite="#c5">attribute to a speed, as a
-              non-negative real number of meters per second, or as `null` if
-              the implementation cannot provide speed information.</ins>
-              </li>
-              <li>Initialize |coord|'s {{GeolocationCoordinates/heading}}
-              <del cite="#c5">attribute in degrees, or `null` if the
-              implementation cannot provide heading information. If the hosting
-              device is stationary (i.e., the value of the
-              {{GeolocationCoordinates/speed}} attribute is 0), then initialize
-              the {{GeolocationCoordinates/heading}} to `NaN`.</del>
-                <ins cite="#c5">attribute to a heading, in degrees, or `null`
-                if the implementation cannot provide heading information. If
-                the hosting device is stationary (i.e., the value of the
+            <div class="correction" id="c4">
+              <span class="marker">Candidate Correction:</span> Enhanced the
+              constructor steps for {{GeolocationCoordinates}} to take
+              arguments from call site.
+              <ol>
+                <li>Initialize |coord|'s {{GeolocationCoordinates/latitude}}
+                attribute to <del>a geographic coordinate in decimal
+                degrees.</del> <ins>|latitude|.</ins>
+                </li>
+                <li>Initialize |coord|'s {{GeolocationCoordinates/longitude}}
+                attribute to <del>a geographic coordinate in decimal
+                degrees.</del> <ins>|longitude|.</ins>
+                </li>
+                <li>Initialize |coord|'s {{GeolocationCoordinates/altitude}}
+                <del>attribute in meters above the [[WGS84]] ellipsoid, or
+                `null` if the implementation cannot provide altitude
+                information.</del> <ins>attribute to |altitude|.</ins>
+                </li>
+                <li>Initialize |coord|'s {{GeolocationCoordinates/speed}}
+                attribute to <del>a non-negative real number, or as `null` if
+                the implementation cannot provide speed information.</del>
+                <ins>|speed|.</ins>
+                </li>
+                <li>Initialize |coord|'s {{GeolocationCoordinates/heading}}
+                <del>attribute in degrees, or `null` if the implementation
+                cannot provide heading information. If the hosting device is
+                stationary (i.e., the value of the
                 {{GeolocationCoordinates/speed}} attribute is 0), then
                 initialize the {{GeolocationCoordinates/heading}} to
-                `NaN`.</ins>
-              </li>
-              <li>Initialize |coord|'s {{GeolocationCoordinates/accuracy}}
-              attribute to a non-negative real number. The value SHOULD
-              correspond to a 95% confidence level with respect to the
-              longitude and latitude values.
-              </li>
-              <li>Initialize |coord|'s
-              {{GeolocationCoordinates/altitudeAccuracy}} attribute as
-              non-negative real number, or to `null` if the implementation
-              cannot provide altitude information. If the altitude accuracy
-              information is provided, it SHOULD correspond to a 95% confidence
-              level.
-              </li>
-            </ol>
+                `NaN`.</del> <ins>attribute to |heading|.</ins>
+                </li>
+                <li>Initialize |coord|'s {{GeolocationCoordinates/accuracy}}
+                attribute to <del>a non-negative real number. The value SHOULD
+                correspond to a 95% confidence level with respect to the
+                longitude and latitude values.</del> <ins>|accuracy|.</ins>
+                </li>
+                <li>Initialize |coord|'s
+                {{GeolocationCoordinates/altitudeAccuracy}} attribute <del>as
+                non-negative real number, or to `null` if the implementation
+                cannot provide altitude information. If the altitude accuracy
+                information is provided, it SHOULD correspond to a 95%
+                confidence level.</del> <ins>to |altitudeAccuracy|.</ins>
+                </li>
+              </ol>
+            </div>
           </li>
           <li>Return a newly created {{GeolocationPosition}} instance with its
           {{GeolocationPosition/coords}} attribute initialized to |coords| and

--- a/index.html
+++ b/index.html
@@ -963,7 +963,7 @@
                       <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
                       |position|.
                       </li>
-                    </ol></ins> <del>
+                    </ol></ins> <del cite="#c9">
                     <ol>
                       <li>Set |position| to [=a new `GeolocationPosition`=]
                       passing |acquisitionTime| and


### PR DESCRIPTION
Enhance the "Acquire a Position" algorithm to include explicit data type definitions and unit specifications for each piece of acquired position data, aligning with the [[WGS84]] coordinate system standards. This update ensures each parameter (latitude, longitude, altitude, etc.) is clearly defined at the point of data acquisition.

Additionally, refine the handling of cached position data within the algorithm. Introduce conditional logic to terminate the algorithm early if a valid cached position is used, preventing unnecessary data acquisition steps. This change improves efficiency and clarity in the geolocation process, ensuring that position data is handled correctly based on its freshness and accuracy requirements.

Key Changes:
- Define explicit data types and units for latitude, longitude, altitude, accuracy, altitude accuracy, speed, and heading.
- Implement conditional checks to skip unnecessary acquisition steps when using cached positions.
- Update parameters passed to the `GeolocationPosition` constructor to include all newly defined data points.

Closes #137

This change is editorial and just contains corrections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/153.html" title="Last updated on Jun 14, 2024, 7:02 AM UTC (06a7881)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/153/c2fdd74...06a7881.html" title="Last updated on Jun 14, 2024, 7:02 AM UTC (06a7881)">Diff</a>