### PR TITLE
link fix for ipr

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       github: "w3c/geolocation",
       caniuse: "geolocation",
       testSuiteURI: "https://wpt.live/geolocation/",
-      implementationReportURI: "https://w3c.github.io/geolocation-api/reports/implementation.html",
+      implementationReportURI: "https://w3c.github.io/geolocation/reports/implementation.html",
       xref: "web-platform",
       errata: "https://w3c.github.io/geolocation/errata.html",
       latestVersion: "https://www.w3.org/TR/geolocation/",


### PR DESCRIPTION
fix regression by 2d0383a

Closes nothing.

also need to sync gh-pages branch to main, for /reports/ directory.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/pull/166.html" title="Last updated on Jun 17, 2024, 4:34 PM UTC (cfdd805)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/166/0fb6edc...cfdd805.html" title="Last updated on Jun 17, 2024, 4:34 PM UTC (cfdd805)">Diff</a>