### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,7 +849,7 @@
                         <ol>
                           <li>[=Queue a task=] on the [=geolocation task
                           source=] with a step that [=invokes=]
-                          |successCallback| with |cachedPosition|.
+                          |successCallback| with « |cachedPosition| » and "`report`".
                           </li>
                           <li>Terminate this algorithm.
                           </li>
@@ -971,7 +971,8 @@
                   <li>Stop the |timeout|.
                   </li>
                   <li>[=Queue a task=] on the [=geolocation task source=] with
-                  a step that [=invokes=] |successCallback| with |position|.
+                  a step that [=invokes=] |successCallback| with « |position| »
+                  and "`report`".
                   </li>
                 </ol>
               </li>
@@ -1043,7 +1044,7 @@
           {{GeolocationPositionError/code}} attribute is initialized to |code|.
           </li>
           <li>[=Queue a task=] on the [=geolocation task source=] with a step
-          that [=invokes=] |callback| with |error|.
+          that [=invokes=] |callback| with « |error| » and "`report`".
           </li>
         </ol>
       </section>


### PR DESCRIPTION
This algorithm can now handle the need to report an exception thrown by the callback. Some small tweaks are made for consistency with other specifications.

Part of whatwg/webidl#1425.


The following tasks have been completed:

 * [x] Modified Web platform tests (link to pull request): n/a (non-normative change)

Implementation commitment (and no objections): n/a (non-normative change)

Documentation (new feature): n/a (non-normative change)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/w3c-geolocation/pull/172.html" title="Last updated on Aug 8, 2024, 9:19 PM UTC (2a69705)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/172/b0ca499...jeremyroman:2a69705.html" title="Last updated on Aug 8, 2024, 9:19 PM UTC (2a69705)">Diff</a>