### PR TITLE
Correction: Use null instead of NaN when stationary

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,10 +943,9 @@
                           </dt>
                           <dd>
                             A {{double?}} that represents the heading in
-                            degrees, or `null` if not available, or `NaN` if
-                            the device is stationary. Heading measures the
-                            direction in which the device is moving relative to
-                            true north.
+                            degrees, or `null` if not available or the device
+                            is stationary. Heading measures the direction in
+                            which the device is moving relative to true north.
                           </dd>
                         </dl>
                       </li>


### PR DESCRIPTION
This ammends the existing correction clarifying the units and conditions for the heading property. This matches existing implementations which return null in this scenario.

Closes #171.

The following tasks have been completed:

 * [ ] ~~Modified Web platform tests (link to pull request)~~

Implementation commitment (and no objections):

 * [x] WebKit (existing behavior)
 * [x] Chromium (existing behavior)
 * [x] Gecko (existing behavior)

Documentation (new feature):

 * [ ] ~~Updated implementation report~~
 * [x] Pinged MDN (https://github.com/mdn/content/pull/35469)
 * [ ] ~~Added example to README or spec~~

For documentation, either create an [issue](https://github.com/mdn/content/issues) or pull request in [MDN's Content](https://github.com/mdn/content) repo  - providing as much information as you can. PR is prefered.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/pull/173.html" title="Last updated on Aug 14, 2024, 7:46 PM UTC (551519b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/173/9ae72d3...551519b.html" title="Last updated on Aug 14, 2024, 7:46 PM UTC (551519b)">Diff</a>