### PR TITLE
Correction: Clarify that only the emulated error code is used

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,7 +838,7 @@
                             <li>If |emulatedPositionData| is a {{GeolocationPositionError}}:
                               <ol>
                                 <li>[=Call back with error=] passing |errorCallback| and
-                                  |emulatedPositionData|.
+                                  |emulatedPositionData|.{{GeolocationPositionError/code}}.
                                 </li>
                                 <li>Terminate this algorithm.</li>
                               </ol>


### PR DESCRIPTION
The "call back with error" algorithm expects only an error code. Extract this from the GeolocationPositionError provided by the automation API.

Fixed #186.