### PR TITLE
convert fix by (part of) PR #129 into candidate correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,6 +669,10 @@
           |errorCallback:PositionErrorCallback?|, a {{PositionOptions}}
           |options:PositionOptions|, and an optional |watchId:unsigned long|:
         </p>
+        <aside class="correction" id="c10">
+          <span class="marker">Candidate Correction:</span>
+           Correct an algorithm of "Request a position" with only switching to "in parallel" when doing the permissions check and thereafter.
+        </aside>
         <ol class="algorithm">
           <li>Let |watchIDs:List| be |geolocation|'s
           {{Geolocation/[[watchIDs]]}}.
@@ -720,6 +724,61 @@
           <li>Let |descriptor| be a new {{PermissionDescriptor}} whose
           {{PermissionDescriptor/name}} is <a>"geolocation"</a>.
           </li>
+          <del cite="#c10">
+          <li>Set |permission| to [=request permission to use=] |descriptor|.
+          </li>
+          <li data-tests=
+          "getCurrentPosition_permission_allow.https.html, getCurrentPosition_permission_deny.https.html">
+          If |permission| is "denied", then:
+            <ol>
+              <li>If |watchId| was passed, [=list/remove=] |watchId| from
+              |watchIDs|.
+              </li>
+              <li>[=Call back with error=] passing |errorCallback| and
+              {{GeolocationPositionError/PERMISSION_DENIED}}.
+              </li>
+              <li>Terminate this algorithm.
+              </li>
+            </ol>
+          </li>
+          <li>Wait to [=acquire a position=] passing |successCallback|,
+          |errorCallback|, |options|, and |watchId|.
+          </li>
+          <li>If |watchId| was not passed, terminate this algorithm.
+          </li>
+          <li>While |watchIDs| [=list/contains=] |watchId|:
+            <ol>
+              <li>
+                <span id="wait-for-change">Wait for a significant change of
+                geographic position</span>. What constitutes a significant
+                change of geographic position is left to the implementation.
+                User agents MAY impose a rate limit on how frequently position
+                changes are reported.
+              </li>
+              <li>If |document| is not [=Document/fully active=] or
+              [=Document/visibility state=] is not "visible", go back to the
+              previous step and again <a href="#wait-for-change">wait for a
+              significant change of geographic position</a>.
+                <aside class="note" title=
+                "Position updates are exclusively for fully-active visible documents">
+                  <p>
+                    The desired effect here being that position updates are
+                    exclusively delivered to fully active documents that are
+                    visible; Otherwise the updates get silently "dropped on the
+                    floor". Only once a document again becomes fully active and
+                    visible (e.g., an [^iframe^] gets reattached to a parent
+                    document), do the position updates once again start getting
+                    delivered.
+                  </p>
+                </aside>
+              </li>
+              <li>Wait to [=acquire a position=] passing |successCallback|,
+              |errorCallback|, |options|, and |watchId|.
+              </li>
+            </ol>
+          </li>
+          </del>
+          <ins cite="#c10">
           <li>[=In parallel=]:
             <ol>
               <li>Set |permission| to [=request permission to use=]
@@ -779,6 +838,7 @@
               </li>
             </ol>
           </li>
+          </ins>
         </ol>
       </section>
       <section>


### PR DESCRIPTION
for part of #188 (1st one)

- no spec text change, purely markup fix, using candidate correction
- text in line 674 need to be reviewed
- since fix spans over multiple li, candidate correction box are inserted at beginning of listing part
- note, original (by means of "show current") had markup error, so html source diff will list some difference