### PR TITLE
revert wrongly deleted text for Candidate Addition 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,7 +1282,14 @@
           specified in decimal degrees.</del> <ins cite="#c3">The
           <dfn>latitude</dfn> and <dfn>longitude</dfn> attributes denote the
           position, specified as a real number of degrees, in the [[WGS84]]
-          coordinate system.</ins> <ins cite="#a3">The <dfn>accuracy</dfn>
+          coordinate system.</ins>
+        </p>
+        <p>
+          <del cite="#a3">
+          The <dfn>accuracy</dfn> attribute denotes the accuracy level of the
+          latitude and longitude coordinates in meters (e.g., `65` meters).
+          </del>
+          <ins cite="#a3">The <dfn>accuracy</dfn>
           attribute denotes the position accuracy radius in meters.</ins>
         </p>
       </section>


### PR DESCRIPTION
for part of #188 (2nd)

This part of text seems wrongly removed at direct commit to main branch without any PR https://github.com/w3c/geolocation/commit/bfb5325e68e862e888d422f5d717d2da49e566e4 , for marking up candidate correction c3. With moving original (at the latest full-REC) text, it seems this change is just rewording.

I'd want to ask whether we should keep this candidate addition as is, mark as purely editorial (wording change), or even revert them.