### PR TITLE
updated changes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1596,20 +1596,38 @@
       <h2>
         Change log
       </h2>
+      <h3 id="changes-20220901">
+        Changes since <a href="https://www.w3.org/TR/2022/REC-geolocation-20220901/">Recommendation, 1 September 2022</a>
+      </h3>
       <p>
-        Since First Public Working Draft in 2021, <cite>Geolocation</cite> has
+        Since publication of the Recommendation in 2022, this specification has
         received the following normative changes:
       </p>
-      <script class="removeOnSave">
-        function removeCommits(commit) {
-          const { message, hash } = commit;
-          if (["ef098b1"].includes(hash)) {
-            return false;
-          }
-          return !/^Clarify which FPWD|^Merge pull|^tidy|^editorial|^Editiorial|^edtiorial|^chore|^refactor|^tests?|^docs|^typo|^nit/i.test(message);
-        }
-      </script> <rs-changelog from="FPWD" filter=
-      "removeCommits"></rs-changelog>
+      <ul>
+        <li><a href="https://github.com/w3c/geolocation/commit/0cc35fa">Correction: Clarify that only the emulated error code is used</a> (<a href="https://github.com/w3c/geolocation/pull/187">#187</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/69cc724">Addition: support geolocation emulation</a> (<a href="https://github.com/w3c/geolocation/pull/183">#183</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/9d5829e">Correction: Use null instead of NaN when stationary</a> (<a href="https://github.com/w3c/geolocation/pull/173">#173</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/22ed7a4">Correction: Update acquisition algorithm to define data types and handle cached positions</a> (<a href="https://github.com/w3c/geolocation/pull/153">#153</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/a30d713">Addition: Define units for accuracy</a> (<a href="https://github.com/w3c/geolocation/pull/162">#162</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/c2fdd74">Correction: check for non-secure contexts</a> (<a href="https://github.com/w3c/geolocation/pull/157">#157</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/09b48e6">Addition: expose .toJSON() on GeolocationCoordinates + GeolocationPosition</a> (<a href="https://github.com/w3c/geolocation/pull/147">#147</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/74b1dd0">Correction: Clarify units and reference geodetic system for latitude and longitude</a> (<a href="https://github.com/w3c/geolocation/pull/138">#138</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/f8b930f">Added webapps as group</a> (<a href="https://github.com/w3c/geolocation/pull/144">#144</a>)</li>
+        <li><a href="https://github.com/w3c/geolocation/commit/7082b4e">Fix references to "default allowlist"</a> (<a href="https://github.com/w3c/geolocation/pull/133">#133</a>)</li>
+      </ul>
+      <h3 id="changes-20210527-20220901">
+        Changes since <a href="https://www.w3.org/TR/2021/WD-geolocation-20210527/">First Public Working Draft, 27 May 2021</a>
+      </h3>
+      <p>
+        Since publication of the First Public Working Draft in 2021, this
+        specification received the following substantive changes:
+      </p>
+      <ul>
+      <li><a href="https://github.com/w3c/geolocation-api/commit/514f15b">fix "Queue a task" / "in parallel" usage</a> (<a href="https://github.com/w3c/geolocation-api/pull/118">#118</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/a1531cb">Suggest permission lifetime</a> (<a href="https://github.com/w3c/geolocation-api/pull/108">#108</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/0c378d9">Handle OS-level permission change</a> (<a href="https://github.com/w3c/geolocation-api/pull/109">#109</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/2a116d7">Switch DOMTimeStamp to EpochTimeStamp</a> (<a href="https://github.com/w3c/geolocation-api/pull/104">#104</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/2c0c516">Return 0 when watchPosition() errors</a> (<a href="https://github.com/w3c/geolocation-api/pull/100">#100</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/de05002">Callback with error if doc is not fully active</a> (<a href="https://github.com/w3c/geolocation-api/pull/97">#97</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/f4605e5">Gracefully handle documents that are not fully active</a> (<a href="https://github.com/w3c/geolocation-api/pull/90">#90</a>)</li><li><a href="https://github.com/w3c/geolocation-api/commit/41d7945">Add "geolocation task queue"</a> (<a href="https://github.com/w3c/geolocation-api/pull/87">#87</a>)</li>
+      </ul>
+      <h3 id="changes-20161108-20210527">
+        Changes since <a href="https://www.w3.org/TR/2016/REC-geolocation-API-20161108/">the Second Edition, 8 November 2016</a>
+      </h3>
       <p>
         Since publication of the Second Edition in 2016, this specification
         received the following substantive changes:


### PR DESCRIPTION
part of #188 (3rd)

- restored change log inserted at 2022 REC publication
- turned rs-changelog into ul/li list for 2022 REC to current


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/w3c-spec-geolocation/pull/199.html" title="Last updated on Sep 22, 2025, 1:35 PM UTC (453764b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/199/66b81bd...himorin:453764b.html" title="Last updated on Sep 22, 2025, 1:35 PM UTC (453764b)">Diff</a>