### PR TITLE
Editorial: Fix ins/dels for c10

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,7 +749,7 @@
           <li>While |watchIDs| [=list/contains=] |watchId|:
             <ol>
               <li>
-                <span id="wait-for-change">Wait for a significant change of
+                <span id="wait-for-change-del">Wait for a significant change of
                 geographic position</span>. What constitutes a significant
                 change of geographic position is left to the implementation.
                 User agents MAY impose a rate limit on how frequently position
@@ -757,7 +757,7 @@
               </li>
               <li>If |document| is not [=Document/fully active=] or
               [=Document/visibility state=] is not "visible", go back to the
-              previous step and again <a href="#wait-for-change">wait for a
+              previous step and again <a href="#wait-for-change-del">wait for a
               significant change of geographic position</a>.
                 <aside class="note" title=
                 "Position updates are exclusively for fully-active visible documents">

--- a/index.html
+++ b/index.html
@@ -669,9 +669,16 @@
           |errorCallback:PositionErrorCallback?|, a {{PositionOptions}}
           |options:PositionOptions|, and an optional |watchId:unsigned long|:
         </p>
+        <aside class="correction" id="c7">
+          <span class="marker">Candidate Correction:</span> Added missing step
+          to handle [=non-secure contexts=].
+        </aside>
         <aside class="correction" id="c10">
-          <span class="marker">Candidate Correction:</span>
-Clarifies when steps are performed in parallel, specifically during the permissions check and subsequent actions. The main change is to correct the algorithm's structure to reflect the intended parallel execution, improving clarity and aligning with implementation expectations.
+          <span class="marker">Candidate Correction:</span> Clarifies when
+          steps are performed in parallel, specifically during the permissions
+          check and subsequent actions. The main change is to correct the
+          algorithm's structure to reflect the intended parallel execution,
+          improving clarity and aligning with implementation expectations.
         </aside>
         <ol class="algorithm">
           <li>Let |watchIDs:List| be |geolocation|'s
@@ -694,11 +701,8 @@ Clarifies when steps are performed in parallel, specifically during the permissi
             </ol>
           </li>
           <li>
-            <aside class="correction" id="c7">
-              <span class="marker">Candidate Correction:</span> Added missing
-              step to handle [=non-secure contexts=].
-            </aside><ins cite="#c7">If |geolocation|'s [=environment settings
-            object=] is a [=non-secure context=]:
+            <ins cite="#c7">If |geolocation|'s [=environment settings object=]
+            is a [=non-secure context=]:
             <ol>
               <li>If |watchId| was passed, [=List/remove=] |watchId| from
               |watchIDs|.
@@ -724,62 +728,8 @@ Clarifies when steps are performed in parallel, specifically during the permissi
           <li>Let |descriptor| be a new {{PermissionDescriptor}} whose
           {{PermissionDescriptor/name}} is <a>"geolocation"</a>.
           </li>
-          <del cite="#c10">
-          <li>Set |permission| to [=request permission to use=] |descriptor|.
-          </li>
-          <li data-tests=
-          "getCurrentPosition_permission_allow.https.html, getCurrentPosition_permission_deny.https.html">
-          If |permission| is "denied", then:
-            <ol>
-              <li>If |watchId| was passed, [=list/remove=] |watchId| from
-              |watchIDs|.
-              </li>
-              <li>[=Call back with error=] passing |errorCallback| and
-              {{GeolocationPositionError/PERMISSION_DENIED}}.
-              </li>
-              <li>Terminate this algorithm.
-              </li>
-            </ol>
-          </li>
-          <li>Wait to [=acquire a position=] passing |successCallback|,
-          |errorCallback|, |options|, and |watchId|.
-          </li>
-          <li>If |watchId| was not passed, terminate this algorithm.
-          </li>
-          <li>While |watchIDs| [=list/contains=] |watchId|:
-            <ol>
-              <li>
-                <span id="wait-for-change-del">Wait for a significant change of
-                geographic position</span>. What constitutes a significant
-                change of geographic position is left to the implementation.
-                User agents MAY impose a rate limit on how frequently position
-                changes are reported.
-              </li>
-              <li>If |document| is not [=Document/fully active=] or
-              [=Document/visibility state=] is not "visible", go back to the
-              previous step and again <a href="#wait-for-change-del">wait for a
-              significant change of geographic position</a>.
-                <aside class="note" title=
-                "Position updates are exclusively for fully-active visible documents">
-                  <p>
-                    The desired effect here being that position updates are
-                    exclusively delivered to fully active documents that are
-                    visible; Otherwise the updates get silently "dropped on the
-                    floor". Only once a document again becomes fully active and
-                    visible (e.g., an [^iframe^] gets reattached to a parent
-                    document), do the position updates once again start getting
-                    delivered.
-                  </p>
-                </aside>
-              </li>
-              <li>Wait to [=acquire a position=] passing |successCallback|,
-              |errorCallback|, |options|, and |watchId|.
-              </li>
-            </ol>
-          </li>
-          </del>
-          <ins cite="#c10">
-          <li>[=In parallel=]:
+          <li>
+            <ins cite="#c10">[=In parallel=]</ins>:
             <ol>
               <li>Set |permission| to [=request permission to use=]
               |descriptor|.
@@ -838,7 +788,6 @@ Clarifies when steps are performed in parallel, specifically during the permissi
               </li>
             </ol>
           </li>
-          </ins>
         </ol>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@
         </p>
         <aside class="correction" id="c10">
           <span class="marker">Candidate Correction:</span>
-           Correct an algorithm of "Request a position" with only switching to "in parallel" when doing the permissions check and thereafter.
+Clarifies when steps are performed in parallel, specifically during the permissions check and subsequent actions. The main change is to correct the algorithm's structure to reflect the intended parallel execution, improving clarity and aligning with implementation expectations.
         </aside>
         <ol class="algorithm">
           <li>Let |watchIDs:List| be |geolocation|'s

--- a/index.html
+++ b/index.html
@@ -669,6 +669,10 @@
           |errorCallback:PositionErrorCallback?|, a {{PositionOptions}}
           |options:PositionOptions|, and an optional |watchId:unsigned long|:
         </p>
+        <aside class="correction" id="c10">
+          <span class="marker">Candidate Correction:</span>
+           Correct an algorithm of "Request a position" with only switching to "in parallel" when doing the permissions check and thereafter.
+        </aside>
         <ol class="algorithm">
           <li>Let |watchIDs:List| be |geolocation|'s
           {{Geolocation/[[watchIDs]]}}.
@@ -720,6 +724,61 @@
           <li>Let |descriptor| be a new {{PermissionDescriptor}} whose
           {{PermissionDescriptor/name}} is <a>"geolocation"</a>.
           </li>
+          <del cite="#c10">
+          <li>Set |permission| to [=request permission to use=] |descriptor|.
+          </li>
+          <li data-tests=
+          "getCurrentPosition_permission_allow.https.html, getCurrentPosition_permission_deny.https.html">
+          If |permission| is "denied", then:
+            <ol>
+              <li>If |watchId| was passed, [=list/remove=] |watchId| from
+              |watchIDs|.
+              </li>
+              <li>[=Call back with error=] passing |errorCallback| and
+              {{GeolocationPositionError/PERMISSION_DENIED}}.
+              </li>
+              <li>Terminate this algorithm.
+              </li>
+            </ol>
+          </li>
+          <li>Wait to [=acquire a position=] passing |successCallback|,
+          |errorCallback|, |options|, and |watchId|.
+          </li>
+          <li>If |watchId| was not passed, terminate this algorithm.
+          </li>
+          <li>While |watchIDs| [=list/contains=] |watchId|:
+            <ol>
+              <li>
+                <span id="wait-for-change">Wait for a significant change of
+                geographic position</span>. What constitutes a significant
+                change of geographic position is left to the implementation.
+                User agents MAY impose a rate limit on how frequently position
+                changes are reported.
+              </li>
+              <li>If |document| is not [=Document/fully active=] or
+              [=Document/visibility state=] is not "visible", go back to the
+              previous step and again <a href="#wait-for-change">wait for a
+              significant change of geographic position</a>.
+                <aside class="note" title=
+                "Position updates are exclusively for fully-active visible documents">
+                  <p>
+                    The desired effect here being that position updates are
+                    exclusively delivered to fully active documents that are
+                    visible; Otherwise the updates get silently "dropped on the
+                    floor". Only once a document again becomes fully active and
+                    visible (e.g., an [^iframe^] gets reattached to a parent
+                    document), do the position updates once again start getting
+                    delivered.
+                  </p>
+                </aside>
+              </li>
+              <li>Wait to [=acquire a position=] passing |successCallback|,
+              |errorCallback|, |options|, and |watchId|.
+              </li>
+            </ol>
+          </li>
+          </del>
+          <ins cite="#c10">
           <li>[=In parallel=]:
             <ol>
               <li>Set |permission| to [=request permission to use=]
@@ -779,6 +838,7 @@
               </li>
             </ol>
           </li>
+          </ins>
         </ol>
       </section>
       <section>


### PR DESCRIPTION
Closes #197

This pull request improves the documentation and algorithm structure for handling geolocation requests in `index.html`. The main focus is on clarifying the handling of non-secure contexts and specifying when steps should be performed in parallel, making the algorithm more precise and aligned with implementation expectations.

Algorithm and documentation corrections:

* Added a correction note clarifying the handling of [=non-secure contexts=] and included the missing step for this scenario. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R672-R682) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L693-R705)
* Clarified that certain steps, specifically the permissions check and subsequent actions, are performed in parallel, and updated the algorithm structure to reflect this parallel execution. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R672-R682) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L723-R732)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/pull/200.html" title="Last updated on Sep 23, 2025, 4:20 AM UTC (e85885e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/200/fd30892...e85885e.html" title="Last updated on Sep 23, 2025, 4:20 AM UTC (e85885e)">Diff</a>