### PR TITLE
Editorial: define geolocation attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,6 +499,11 @@
           [SameObject] readonly attribute Geolocation geolocation;
         };
       </pre>
+      <h3>`navigator` attribute</h3>
+      <p>
+        The <dfn>geolocation</dfn> attribute provides the entry point for
+        accessing the Geolocation API.
+      </p>
     </section>
     <section id="geolocation_interface" data-dfn-for="Geolocation">
       <h2>


### PR DESCRIPTION
Closes #194

This pull request adds documentation to clarify how the Geolocation API is accessed via the `navigator` attribute. The most important change is an explanatory section in the HTML documentation.

Documentation improvement:

* Added a new `<h3>` section titled "`navigator` attribute" to `index.html`, describing that the `geolocation` attribute on `navigator` is the entry point for accessing the Geolocation API.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/pull/202.html" title="Last updated on Oct 3, 2025, 8:22 AM UTC (02364fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/202/30713be...02364fe.html" title="Last updated on Oct 3, 2025, 8:22 AM UTC (02364fe)">Diff</a>