### PR TITLE
Editorial: fix broken ref + tidy doc

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,10 +384,10 @@
           are typically time-based (e.g., "a day"), or until browser is closed,
           or the user might even be given the choice for the permission to be
           granted indefinitely. The permission [=permission/lifetimes=] dictate
-          how long a user agent [=permission/grants=] a permission before that
-          permission is automatically reverted back to its default [=permission
-          state=], prompting the end-user to make a new choice upon subsequent
-          use.
+          how long a user agent [=permission/granted|grants=] a permission
+          before that permission is automatically reverted back to its default
+          [=permission state=], prompting the end-user to make a new choice
+          upon subsequent use.
         </p>
         <p>
           Although the granularity of the permission [=permission/lifetime=]
@@ -1663,8 +1663,8 @@
       </ul>
       <p>
         See the <a href=
-        "https://github.com/w3c/geolocation/commits/main">commit
-        history</a> for a complete list of changes.
+        "https://github.com/w3c/geolocation/commits/main">commit history</a>
+        for a complete list of changes.
       </p>
     </section>
   </body>


### PR DESCRIPTION
This pull request makes minor formatting and wording adjustments to the `index.html` file to improve readability and consistency.

* fix broken link "[=permission/grants=]" to "[=permission/granted|grants=]".
* Fixed line break formatting in the paragraph referencing the commit history link for better readability.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/pull/203.html" title="Last updated on Oct 3, 2025, 8:26 AM UTC (ab62d31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/203/30713be...ab62d31.html" title="Last updated on Oct 3, 2025, 8:26 AM UTC (ab62d31)">Diff</a>