### PR TITLE
Add missing latitude definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,7 +943,7 @@
                     <ol data-cite="infra">
                       <li>Let |positionData| be a [=map=] with the following
                       name/value pairs based on the acquired position data:
-                        <dl>
+                        <dl data-sort="">
                           <dt>
                             "latitude"
                           </dt>


### PR DESCRIPTION
This pull request adds a detailed description for the `"latitude"` entry in the `positionData` map. The change clarifies that latitude is a double representing north-south position using the WGS84 system.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/pull/208.html" title="Last updated on Oct 28, 2025, 10:13 AM UTC (87b6f22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/208/ae66cdb...87b6f22.html" title="Last updated on Oct 28, 2025, 10:13 AM UTC (87b6f22)">Diff</a>