### PR TITLE
Update implementation report for idlharness.https.window.js tests

### DIFF
--- a/reports/implementation.html
+++ b/reports/implementation.html
@@ -178,9 +178,9 @@
             >idlharness.https.window.js</a
           >
         </td>
-        <td>UNTESTED</td>
-        <td>UNTESTED</td>
-        <td>UNTESTED</td>
+        <td class="pass">PASS</td>
+        <td class="pass">PASS</td>
+        <td class="pass">PASS</td>
       </tr>
       <tr>
         <td>


### PR DESCRIPTION
According to wpt.fyi the idlharness.https.window.js tests pass across Chrome, Firefox and Safari so we can mark these as "PASS".

Issue #215.