### PR TITLE
chore: fix typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@ Documentation (new feature):
  * [ ] Pinged MDN
  * [ ] Added example to README or spec
 
-For documentation, either create an [issue](https://github.com/mdn/content/issues) or pull request in [MDN's Content](https://github.com/mdn/content) repo  - providing as much information as you can. PR is prefered.
+For documentation, either create an [issue](https://github.com/mdn/content/issues) or pull request in [MDN's Content](https://github.com/mdn/content) repo - providing as much information as you can. PR is preferred.


### PR DESCRIPTION
Fixes "prefered" → "preferred" and removes a double space.