### PR TITLE
Add support for approximate location (without separate permission)

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@
         The {{PositionOptions}}'s {{PositionOptions/accuracyMode}} member allows
         websites to declare that they have no need for the user's [=precise
         position=] and can function with only an [=approximate position=]. When
-        an application requests an [=approximate position=] an [=approximate
+        an application requests an [=approximate position=], an [=approximate
         location information source=] is used. Even when a [=precise position=]
         is requested, the user agent MAY provide an [=approximate position=]
         instead (as defined in the [=acquire a position=] algorithm), for
@@ -555,12 +555,19 @@
         </h3>
         <p>
           The [=approximate location information source=] used by the user agent
-          should take into account that a site, by keeping using the API, can
-          receive multiple [=approximate positions=]. Hence it SHOULD, when
+          should take into account that a site, by repeatedly using the API, can
+          receive multiple [=approximate positions=]. Therefore it SHOULD, when
           returning an [=approximate position=], implement measures that
-          mitigate the risk of a refinement attack, preventing the site to
-          potentially infer a user's [=precise position=] by collecting and
+          mitigate the risk of a refinement attack, preventing the site from
+          potentially inferring a user's [=precise position=] by collecting and
           correlating multiple, distinct [=approximate positions=].
+        </p>
+        <p class="note">
+          The chosen accuracy is per request. A user agent that internally
+          shares one acquired position across concurrent requests coarsens it
+          for each {{AccuracyMode/"approximate"}} request when the position is
+          delivered, so an approximate request never receives a precise
+          position acquired for a concurrent request.
         </p>
       </section>
     </section>
@@ -799,6 +806,7 @@
               <li>Let |permission| be the result of [=prompting the user to
               choose=] from |promptOptions| associated with
               <a>"geolocation"</a>.
+              </li>
               <li data-tests=
               "getCurrentPosition_permission_allow.https.html, getCurrentPosition_permission_deny.https.html">
               If |permission| is "denied", then:
@@ -902,6 +910,7 @@
                   position=].
                 </p>
               </aside>
+              </li>
               <li>If |permission| is "denied":
                 <ol>
                   <li>Stop |timeout|.
@@ -934,7 +943,8 @@
                           </li>
                           <li>Let |position| be [=a new `GeolocationPosition`=]
                           passing |emulatedPositionData|, |acquisitionTime| and
-                          |options|.{{PositionOptions/enableHighAccuracy}}.
+                          |options|.{{PositionOptions/enableHighAccuracy}}, and
+                          |permission|.
                           </li>
                           <li>[=Queue a task=] on the [=geolocation task
                           source=] with a step that [=invokes=]
@@ -1195,6 +1205,16 @@
             {{PositionOptions/enableHighAccuracy}} member.
           </p>
         </aside>
+        <aside class="note" title="Granted accuracy is not observable">
+          <p>
+            The granted {{AccuracyMode}} is not exposed to the page:
+            `navigator.permissions.query({name: "geolocation"})` reports the
+            same {{PermissionState}} whether the grant is
+            {{AccuracyMode/"approximate"}} or {{AccuracyMode/"precise"}}, and a
+            delivered {{GeolocationPosition}} carries no attribute indicating
+            which accuracy was granted.
+          </p>
+        </aside>
       </section>
       <section>
         <h3>
@@ -1315,6 +1335,8 @@
               {{PositionOptions/enableHighAccuracy}} member when this
               {{GeolocationPosition}} is [=a new GeolocationPosition|created=].
             </td>
+          </tr>
+          <tr>
             <td>
               <dfn data-dfn-for="GeolocationPosition">[[\accuracyMode]]</dfn>
             </td>
@@ -1424,8 +1446,9 @@
         </h3>
         <p>
           <dfn>A new `GeolocationPosition`</dfn> is constructed with [=map=]
-          |positionData|, {{EpochTimeStamp}} |timestamp:EpochTimeStamp| and
-          boolean |isHighAccuracy| by performing the following steps:
+          |positionData|, {{EpochTimeStamp}} |timestamp:EpochTimeStamp|,
+          boolean |isHighAccuracy|, and {{AccuracyMode}} |accuracyMode| by
+          performing the following steps:
         </p>
         <ol class="algorithm">
           <li>Let |coords:GeolocationCoordinates| be a newly created
@@ -1440,8 +1463,10 @@
           <li>Return a newly created {{GeolocationPosition}} instance with its
           {{GeolocationPosition/coords}} attribute initialized to |coords| and
           {{GeolocationPosition/timestamp}} attribute initialized to
-          |timestamp|, and its {{GeolocationPosition/[[isHighAccuracy]]}}
-          internal slot set to |isHighAccuracy|.
+          |timestamp|, its {{GeolocationPosition/[[isHighAccuracy]]}}
+          internal slot set to |isHighAccuracy|, and its
+          {{GeolocationPosition/[[accuracyMode]]}} internal slot set to
+          |accuracyMode|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -988,7 +988,7 @@
                       </li>
                     </ol>
                   </li>
-                  <li>Ty to acquire position data from the underlying system,
+                  <li>Try to acquire position data from the underlying system,
                   with the following considerations:
                     <ol>
                       <li>If |permission| is {{AccuracyMode/"approximate"}},

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         returns the device's actual location.
       </p>
       <p>
-        If an end user [=check permission|grants permission=],
+        If an end user [=prompt the user to choose|grants permission=],
         <cite>Geolocation</cite>:
       </p>
       <ul>
@@ -104,6 +104,45 @@
         ignored by the user agent.
         </li>
       </ul>
+      <p>
+        This specification provides two ways for users to share their location:
+      </p>
+      <dl>
+        <dt>
+          <dfn>precise position</dfn>
+        </dt>
+        <dd>
+          A position returned by the underlying location information source. By
+          default, any location data is considered precise, regardless of its
+          accuracy estimate, unless it has been explicitly coarsened by an
+          [=approximate location information source=] to be an [=approximate
+          position=].
+        </dd>
+        <dt>
+          <dfn>approximate position</dfn>
+        </dt>
+        <dd>
+          A less [=precise position|precise=] representation of the user's
+          location. Instead of providing precise coordinates, an [=approximate
+          location information source=] returns a location that is coarsened
+          to a larger area, such as the nearest city, postal code, or a
+          predefined region. What constitutes a coarsened area is left to the
+          underlying system, which in turn can vary per jurisdiction.
+          <p class="note" title="Benefits of Approximate Position">
+            An [=approximate position=] is often sufficient for applications
+            that don't need to know the user's [=precise position=], for
+            example, a weather application that only needs a city-level
+            location. By sharing an [=approximate position=], users get the
+            benefit of a location-aware application without potentially
+            revealing their [=precise position=].
+          </p>
+        </dd>
+      </dl>
+      <p>
+        An <dfn>approximate location information source</dfn> is a location
+        information source that returns positions that have been intentionally
+        obfuscated to make it more difficult to recover the true location.
+      </p>
       <section id="scope" class="informative">
         <h3>
           Scope
@@ -133,8 +172,12 @@
           Get current position
         </h3>
         <p>
-          Request the user's current location. If the user allows it, you will
-          get back a position object.
+          A website can request a user's location, choosing either a [=precise
+          position=] or an [=approximate position=] via the
+          {{PositionOptions/accuracyMode}} member. During the [=prompt the user
+          to choose|permission request process, the end-user determines the
+          actual level of accuracy to grant, which the [=user agent=] then uses
+          to provide the geographic position accordingly.
         </p>
         <aside class="example" title="A one-shot position request">
           <pre class="js">
@@ -142,6 +185,16 @@
               const { latitude, longitude } = position.coords;
               // Show a map centered at latitude / longitude.
             });
+          </pre>
+        </aside>
+        <aside class="example" title="Requesting an approximate position">
+          <pre class="js">
+            navigator.geolocation.getCurrentPosition(position =&gt; {
+              const { latitude, longitude } = position.coords;
+              // Use approximate location for city-level features.
+            },
+            console.error,
+            { accuracyMode: "approximate" });
           </pre>
         </aside>
       </section>
@@ -240,23 +293,34 @@
         </h3>
         <p>
           By default, the API always attempts to return a cached position so
-          long as it has a previously acquired position. In this example, we
-          accept a position whose age is no greater than 10 minutes. If the
-          user agent does not have a fresh enough cached position object, it
-          automatically acquires a new position.
+          long as it has a previously acquired position, and that position
+          matches the requested {{PositionOptions/accuracyMode}}. In this
+          example, we request a cached position whose age is no greater than 10
+          minutes. If the user agent does not have a fresh enough cached
+          position object of the correct accuracy, it automatically acquires a
+          new position.
         </p>
         <aside class="example" title="Getting cached position">
           <pre class="js">
+            // Requesting a cached precise position.
+            // Note: `accuracyMode` defaults to "precise".
             navigator.geolocation.getCurrentPosition(
               successCallback,
               console.error,
-              { maximumAge: 600_000 }
+              {
+                maximumAge: 600_000,
+              }
             );
 
-            function successCallback(position) {
-              // By using the 'maximumAge' member above, the position
-              // object is guaranteed to be at most 10 minutes old.
-            }
+            // Requesting a cached approximate position.
+            navigator.geolocation.getCurrentPosition(
+              successCallback,
+              console.error,
+              {
+                maximumAge: 600_000,
+                accuracyMode: "approximate",
+              }
+            );
           </pre>
         </aside>
       </section>
@@ -349,6 +413,17 @@
         information also discloses the location of the user of the device,
         thereby potentially compromising the user's privacy.
       </p>
+      <p>
+        The {{PositionOptions}}'s {{PositionOptions/accuracyMode}} member allows
+        websites to declare that they have no need for the user's [=precise
+        position=] and can function with only an [=approximate position=]. When
+        an application requests an [=approximate position=] an [=approximate
+        location information source=] is used. Even when a [=precise position=]
+        is requested, the user agent MAY provide an [=approximate position=]
+        instead (as defined in the [=acquire a position=] algorithm), for
+        example, if the user has only granted permission for approximate
+        accuracy.
+      </p>
       <section class="informative">
         <h3>
           User consent
@@ -404,6 +479,16 @@
           information against unauthorized access. If location information is
           stored, users need to be allowed to update and delete this
           information.
+        </p>
+        <p>
+          In line with this principle, recipients are strongly encouraged to
+          request the lowest level of location accuracy that is sufficient for
+          their application's functionality. For instance, if an application
+          only needs to know the user's city, it can indicate that to the user
+          by requesting an [=approximate position=], by setting the
+          {{PositionOptions/accuracyMode}} option to
+          {{AccuracyMode/"approximate"}}. This practice of data minimization is
+          a key aspect of respecting user privacy.
         </p>
         <p>
           The recipients of location information need to refrain from
@@ -462,6 +547,20 @@
           be, for example, until the [=environment settings object/realm=] is
           destroyed, the end-user [=navigates=] away from the [=origin=], or
           the relevant browser tab is closed.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Preventing Precise Location Reconstruction
+        </h3>
+        <p>
+          The [=approximate location information source=] used by the user agent
+          should take into account that a site, by keeping using the API, can
+          receive multiple [=approximate positions=]. Hence it SHOULD, when
+          returning an [=approximate position=], implement measures that
+          mitigate the risk of a refinement attack, preventing the site to
+          potentially infer a user's [=precise position=] by collecting and
+          correlating multiple, distinct [=approximate positions=].
         </p>
       </section>
     </section>
@@ -689,14 +788,17 @@
               </li>
             </ol>
           </li>
-          <li>Let |descriptor| be a new {{PermissionDescriptor}} whose
-          {{PermissionDescriptor/name}} is <a>"geolocation"</a>.
-          </li>
           <li>[=In parallel=]:
             <ol>
-              <li>Set |permission| to [=request permission to use=]
-              |descriptor|.
+              <li>Let |promptOptions| be the [=set=] « "approximate" » if
+              |options| {{PositionOptions/accuracyMode}} is
+              {{AccuracyMode/"approximate"}}, or the [=set=] « "approximate",
+              "precise" » if |options| {{PositionOptions/accuracyMode}} is
+              {{AccuracyMode/"precise"}}.
               </li>
+              <li>Let |permission| be the result of [=prompting the user to
+              choose=] from |promptOptions| associated with
+              <a>"geolocation"</a>.
               <li data-tests=
               "getCurrentPosition_permission_allow.https.html, getCurrentPosition_permission_deny.https.html">
               If |permission| is "denied", then:
@@ -783,9 +885,23 @@
           |timeoutTime|, during which it tries to acquire the device's position
           by running the following steps:
             <ol>
-              <li>Let |permission| be [=get the current permission state=] of
-              <a>"geolocation"</a>.
-              </li>
+              <li>Let |promptOptions| be the [=set=] « "approximate" » if
+              |options| {{PositionOptions/accuracyMode}} is
+              {{AccuracyMode/"approximate"}}, or the [=set=] « "approximate",
+              "precise" » if |options| {{PositionOptions/accuracyMode}} is
+              {{AccuracyMode/"precise"}}, and let |permission| be the result
+              of [=prompting the user to choose=] from |promptOptions|
+              associated with <a>"geolocation"</a>.
+              <aside class="note">
+                <p>
+                  Despite the naming, the algorithm [=prompt the user to
+                  choose=] does not necessarily display a prompt to the user if
+                  it has already been called before with the same set of
+                  options. Here, in particular, [=prompt the user to choose=]
+                  has already been called when [=request a position|requesting a
+                  position=].
+                </p>
+              </aside>
               <li>If |permission| is "denied":
                 <ol>
                   <li>Stop |timeout|.
@@ -795,7 +911,7 @@
                   </li>
                 </ol>
               </li>
-              <li>If |permission| is "granted":
+              <li>Otherwise, run the following steps to determine |position|:
                 <ol>
                   <li>Check if an emulated position should be used by running
                   the following steps:
@@ -841,7 +957,11 @@
                       </li>
                       <li>If |cachedPosition|'s
                       {{GeolocationPosition/timestamp}}'s value is greater than
-                      |cacheTime|, and
+                      |cacheTime|,
+                      |cachedPosition|.{{GeolocationPosition/[[accuracyMode]]}}
+                      equals |permission|, and either
+                      |cachedPosition|.{{GeolocationPosition/[[accuracyMode]]}}
+                      is {{AccuracyMode/"approximate"}} or
                       |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
                       equals |options|.{{PositionOptions/enableHighAccuracy}}:
                         <ol>
@@ -856,165 +976,170 @@
                       </li>
                     </ol>
                   </li>
-                  <li>Otherwise, if |position| is not |cachedPosition|, try to
-                  acquire position data from the underlying system, optionally
-                  taking into consideration the value of
-                  |options|.{{PositionOptions/enableHighAccuracy}} during
-                  acquisition.
-                  </li>
-                  <li>If the |timeout| elapses during acquisition, or acquiring
-                  the device's position results in failure:
+                  <li>Otherwise, try to acquire position data from the
+                  underlying system, with the following considerations:
                     <ol>
-                      <li>Stop the |timeout|.
+                      <li>If |permission| is {{AccuracyMode/"approximate"}},
+                      acquire an [=approximate position=]. The
+                      {{PositionOptions/enableHighAccuracy}} member is ignored.
                       </li>
-                      <li>Go to <a href="#errors-reasons">dealing with
-                      failures</a>.
-                      </li>
-                      <li>Terminate this algorithm.
-                      </li>
-                    </ol>
-                  </li>
-                  <li data-cite="infra">If acquiring the position data from the
-                  system succeeds:
-                    <ol data-cite="infra">
-                      <li>Let |positionData| be a [=map=] with the following
-                      name/value pairs based on the acquired position data:
-                        <dl data-sort="">
-                          <dt>
-                            "latitude"
-                          </dt>
-                          <dd>
-                            A {{double}} that represents the latitude
-                            coordinates on the Earth's surface in degrees,
-                            using the [[WGS84]] coordinate system. Latitude
-                            measures how far north or south a point is from the
-                            Equator.
-                          </dd>
-                          <dt>
-                            "longitude"
-                          </dt>
-                          <dd>
-                            A {{double}} that represents the longitude
-                            coordinates on the Earth's surface in degrees,
-                            using the [[WGS84]] coordinate system. Longitude
-                            measures how far east or west a point is from the
-                            Prime Meridian.
-                          </dd>
-                          <dt>
-                            "altitude"
-                          </dt>
-                          <dd>
-                            A {{double?}} that represents the altitude in
-                            meters above the [[WGS84]] ellipsoid, or `null` if
-                            not available. Altitude measures the height above
-                            sea level.
-                          </dd>
-                          <dt>
-                            "accuracy"
-                          </dt>
-                          <dd>
-                            A non-negative {{double}} that represents the
-                            accuracy value indicating the 95% confidence level
-                            in meters. Accuracy measures how close the measured
-                            coordinates are to the true position.
-                          </dd>
-                          <dt>
-                            "altitudeAccuracy"
-                          </dt>
-                          <dd>
-                            A non-negative {{double?}} that represents the
-                            altitude accuracy, or `null` if not available,
-                            indicating the 95% confidence level in meters.
-                            Altitude accuracy measures how close the measured
-                            altitude is to the true altitude.
-                          </dd>
-                          <dt>
-                            "speed"
-                          </dt>
-                          <dd>
-                            A non-negative {{double?}} that represents the
-                            speed in meters per second, or `null` if not
-                            available. Speed measures how fast the device is
-                            moving.
-                          </dd>
-                          <dt>
-                            "heading"
-                          </dt>
-                          <dd>
-                            A {{double?}} that represents the heading in
-                            degrees, or `null` if not available or the device
-                            is stationary. Heading measures the direction in
-                            which the device is moving relative to true north.
-                          </dd>
-                        </dl>
-                      </li>
-                      <li>Set |position| to [=a new `GeolocationPosition`=]
-                      passing |positionData|, |acquisitionTime| and
+                      <li>If |permission| is {{AccuracyMode/"precise"}},
+                      acquire a [=precise position=], optionally taking into
+                      consideration the value of
                       |options|.{{PositionOptions/enableHighAccuracy}}.
                       </li>
-                      <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
-                      |position|.
-                      </li>
                     </ol>
-                  </li>
-                  <li>Stop the |timeout|.
-                  </li>
-                  <li>[=Queue a task=] on the [=geolocation task source=] with
-                  a step that [=invokes=] |successCallback| with « |position| »
-                  and "`report`".
                   </li>
                 </ol>
               </li>
-            </ol>
-            <dl class="switch">
-              <dt id="errors-reasons">
-                Dealing with failures:
-              </dt>
-              <dd>
-                <ul>
-                  <li>If acquiring a position fails, do one of the following
-                  based on the condition that matches the failure:
-                    <dl class="switch">
-                      <dt id="permission-denied">
-                        User or system denied permission:
+              <li>If the |timeout| elapses during acquisition, or acquiring the
+              device's position results in failure:
+                <ol>
+                  <li>Stop the |timeout|.
+                  </li>
+                  <li>[=Deal with failure=].
+                  </li>
+                  <li>Terminate this algorithm.
+                  </li>
+                </ol>
+              </li>
+              <li data-cite="infra">If acquiring the position data from the
+              system succeeds:
+                <ol>
+                  <li>Let |positionData| be a [=map=] with the following
+                  name/value pairs based on the acquired position data:
+                    <dl data-sort="">
+                      <dt>
+                        "latitude"
                       </dt>
                       <dd>
-                        <p>
-                          [=Call back with error=] passing |errorCallback| and
-                          {{GeolocationPositionError/PERMISSION_DENIED}}.
-                        </p>
-                        <aside class="note" title=
-                        "Browser permission VS OS permission">
-                          <p>
-                            On certain platforms, there can be a circumstance
-                            where the user has [=permission/granted=] the user
-                            agent permission to use Geolocation at the
-                            browser-level, but the permission to access
-                            location services has been denied at the OS level.
-                          </p>
-                        </aside>
+                        A {{double}} that represents the latitude coordinates
+                        on the Earth's surface in degrees, using the [[WGS84]]
+                        coordinate system. Latitude measures how far north or
+                        south a point is from the Equator.
                       </dd>
                       <dt>
-                        Timeout elapsed:
+                        "longitude"
                       </dt>
                       <dd>
-                        [=Call back with error=] with |errorCallback| and
-                        {{GeolocationPositionError/TIMEOUT}}.
+                        A {{double}} that represents the longitude coordinates
+                        on the Earth's surface in degrees, using the [[WGS84]]
+                        coordinate system. Longitude measures how far east or
+                        west a point is from the Prime Meridian.
                       </dd>
                       <dt>
-                        Data acquisition error or any other reason:
+                        "altitude"
                       </dt>
                       <dd>
-                        [=Call back with error=] passing |errorCallback| and
-                        {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
+                        A {{double?}} that represents the altitude in meters
+                        above the [[WGS84]] ellipsoid, or `null` if not
+                        available. Altitude measures the height above sea
+                        level.
+                      </dd>
+                      <dt>
+                        "accuracy"
+                      </dt>
+                      <dd>
+                        A non-negative {{double}} that represents the accuracy
+                        value indicating the 95% confidence level in meters.
+                        Accuracy measures how close the measured coordinates
+                        are to the true position.
+                      </dd>
+                      <dt>
+                        "altitudeAccuracy"
+                      </dt>
+                      <dd>
+                        A non-negative {{double?}} that represents the altitude
+                        accuracy, or `null` if not available, indicating the
+                        95% confidence level in meters. Altitude accuracy
+                        measures how close the measured altitude is to the true
+                        altitude.
+                      </dd>
+                      <dt>
+                        "speed"
+                      </dt>
+                      <dd>
+                        A non-negative {{double?}} that represents the speed in
+                        meters per second, or `null` if not available. Speed
+                        measures how fast the device is moving.
+                      </dd>
+                      <dt>
+                        "heading"
+                      </dt>
+                      <dd>
+                        A {{double?}} that represents the heading in degrees,
+                        or `null` if not available or the device is stationary.
+                        Heading measures the direction in which the device is
+                        moving relative to true north.
                       </dd>
                     </dl>
                   </li>
-                </ul>
-              </dd>
-            </dl>
+                  <li>Set |position| to [=a new `GeolocationPosition`=] passing
+                  |positionData|, |acquisitionTime|,
+                  |options|.{{PositionOptions/enableHighAccuracy}}, and
+                  |permission|.
+                  </li>
+                  <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
+                  |position|.
+                  </li>
+                </ol>
+              </li>
+              <li>Stop the |timeout|.
+              </li>
+              <li>[=Queue a task=] on the [=geolocation task source=] with a
+              step that [=invokes=] |successCallback| with « |position| » and
+              "`report`".
+              </li>
+            </ol>
           </li>
         </ol>
+        <dl class="switch">
+          <dt id="errors-reasons">
+            <dfn>Deal with failure</dfn>:
+          </dt>
+          <dd>
+            <ul>
+              <li>If acquiring a position fails, do one of the following based
+              on the condition that matches the failure:
+                <dl class="switch">
+                  <dt id="permission-denied">
+                    User or system denied permission:
+                  </dt>
+                  <dd>
+                    <p>
+                      [=Call back with error=] passing |errorCallback| and
+                      {{GeolocationPositionError/PERMISSION_DENIED}}.
+                    </p>
+                    <aside class="note" title=
+                    "Browser permission VS OS permission">
+                      <p>
+                        On certain platforms, there can be a circumstance where
+                        the user has [=permission/granted=] the user agent
+                        permission to use Geolocation at the browser-level, but
+                        the permission to access location services has been
+                        denied at the OS level.
+                      </p>
+                    </aside>
+                  </dd>
+                  <dt>
+                    Timeout elapsed:
+                  </dt>
+                  <dd>
+                    [=Call back with error=] with |errorCallback| and
+                    {{GeolocationPositionError/TIMEOUT}}.
+                  </dd>
+                  <dt>
+                    Data acquisition error or any other reason:
+                  </dt>
+                  <dd>
+                    [=Call back with error=] passing |errorCallback| and
+                    {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
+                  </dd>
+                </dl>
+              </li>
+            </ul>
+          </dd>
+        </dl>
       </section>
       <section>
         <h3>
@@ -1043,12 +1168,34 @@
         <dfn>PositionOptions</dfn> dictionary
       </h2>
       <pre class="idl">
+        enum AccuracyMode {
+          "precise",
+          "approximate"
+        };
+
         dictionary PositionOptions {
+          AccuracyMode accuracyMode = "precise";
           boolean enableHighAccuracy = false;
           [Clamp] unsigned long timeout = 0xFFFFFFFF;
           [Clamp] unsigned long maximumAge = 0;
         };
         </pre>
+      <section>
+        <h3>
+          `accuracyMode` member
+        </h3>
+        <p>
+          The <dfn>accuracyMode</dfn> member is used to request a specific
+          level of accuracy.
+        </p>
+        <aside class="note" title="Interaction with enableHighAccuracy">
+          <p>
+            If {{PositionOptions/accuracyMode}} is set to
+            {{AccuracyMode/"approximate"}}, the [=user agent=] ignores the
+            {{PositionOptions/enableHighAccuracy}} member.
+          </p>
+        </aside>
+      </section>
       <section>
         <h3>
           `enableHighAccuracy` member
@@ -1167,6 +1314,14 @@
               A {{boolean}} that records the value of the
               {{PositionOptions/enableHighAccuracy}} member when this
               {{GeolocationPosition}} is [=a new GeolocationPosition|created=].
+            </td>
+            <td>
+              <dfn data-dfn-for="GeolocationPosition">[[\accuracyMode]]</dfn>
+            </td>
+            <td>
+              An {{AccuracyMode}} that records the chosen {{AccuracyMode}}
+              when this {{GeolocationPosition}} is [=a new
+              GeolocationPosition|created=].
             </td>
           </tr>
         </table>

--- a/index.html
+++ b/index.html
@@ -803,13 +803,13 @@
               "precise" » if |options| {{PositionOptions/accuracyMode}} is
               {{AccuracyMode/"precise"}}.
               </li>
-              <li>Let |permission| be the result of [=prompting the user to
+              <li>Let |choice| be the result of [=prompting the user to
               choose=] from |promptOptions| associated with
               <a>"geolocation"</a>.
               </li>
               <li data-tests=
               "getCurrentPosition_permission_allow.https.html, getCurrentPosition_permission_deny.https.html">
-              If |permission| is "denied", then:
+              If |choice| is "denied", then:
                 <ol>
                   <li>If |watchId| was passed, [=list/remove=] |watchId| from
                   |watchIDs|.
@@ -897,7 +897,7 @@
               |options| {{PositionOptions/accuracyMode}} is
               {{AccuracyMode/"approximate"}}, or the [=set=] « "approximate",
               "precise" » if |options| {{PositionOptions/accuracyMode}} is
-              {{AccuracyMode/"precise"}}, and let |permission| be the result
+              {{AccuracyMode/"precise"}}, and let |choice| be the result
               of [=prompting the user to choose=] from |promptOptions|
               associated with <a>"geolocation"</a>.
               <aside class="note">
@@ -911,7 +911,7 @@
                 </p>
               </aside>
               </li>
-              <li>If |permission| is "denied":
+              <li>If |choice| is "denied":
                 <ol>
                   <li>Stop |timeout|.
                   </li>
@@ -944,9 +944,9 @@
                             </ol>
                           </li>
                           <li>Let |position| be [=a new `GeolocationPosition`=]
-                          passing |emulatedPositionData|, |acquisitionTime| and
+                          passing |emulatedPositionData|, |acquisitionTime|,
                           |options|.{{PositionOptions/enableHighAccuracy}}, and
-                          |permission|.
+                          |choice|.
                           </li>
                           <li>[=Queue a task=] on the [=geolocation task
                           source=] with a step that [=invokes=]
@@ -971,7 +971,7 @@
                       {{GeolocationPosition/timestamp}}'s value is greater than
                       |cacheTime|,
                       |cachedPosition|.{{GeolocationPosition/[[accuracyMode]]}}
-                      equals |permission|, and either
+                      equals |choice|, and either
                       |cachedPosition|.{{GeolocationPosition/[[accuracyMode]]}}
                       is {{AccuracyMode/"approximate"}} or
                       |cachedPosition|.{{GeolocationPosition/[[isHighAccuracy]]}}
@@ -991,11 +991,11 @@
                   <li>Try to acquire position data from the underlying system,
                   with the following considerations:
                     <ol>
-                      <li>If |permission| is {{AccuracyMode/"approximate"}},
+                      <li>If |choice| is {{AccuracyMode/"approximate"}},
                       acquire an [=approximate position=]. The
                       {{PositionOptions/enableHighAccuracy}} member is ignored.
                       </li>
-                      <li>If |permission| is {{AccuracyMode/"precise"}},
+                      <li>If |choice| is {{AccuracyMode/"precise"}},
                       acquire a [=precise position=], optionally taking into
                       consideration the value of
                       |options|.{{PositionOptions/enableHighAccuracy}}.
@@ -1089,7 +1089,7 @@
                   <li>Set |position| to [=a new `GeolocationPosition`=] passing
                   |positionData|, |acquisitionTime|,
                   |options|.{{PositionOptions/enableHighAccuracy}}, and
-                  |permission|.
+                  |choice|.
                   </li>
                   <li>Set [=this=]'s {{Geolocation/[[cachedPosition]]}} to
                   |position|.
@@ -1453,6 +1453,10 @@
           performing the following steps:
         </p>
         <ol class="algorithm">
+          <li>If |accuracyMode| is {{AccuracyMode/"approximate"}}, set
+          |positionData|["altitude"], |positionData|["altitudeAccuracy"],
+          |positionData|["speed"], and |positionData|["heading"] to null.
+          </li>
           <li>Let |coords:GeolocationCoordinates| be a newly created
           {{GeolocationCoordinates}} instance.
           </li>

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
           A website can request a user's location, choosing either a [=precise
           position=] or an [=approximate position=] via the
           {{PositionOptions/accuracyMode}} member. During the [=prompt the user
-          to choose|permission request process, the end-user determines the
+          to choose|permission request process=], the end-user determines the
           actual level of accuracy to grant, which the [=user agent=] then uses
           to provide the geographic position accordingly.
         </p>
@@ -918,6 +918,8 @@
                   <li>Do the <a href="#permission-denied">user or system denied
                   permission</a> failure case step.
                   </li>
+                  <li>Terminate this algorithm.
+                  </li>
                 </ol>
               </li>
               <li>Otherwise, run the following steps to determine |position|:
@@ -986,8 +988,8 @@
                       </li>
                     </ol>
                   </li>
-                  <li>Otherwise, try to acquire position data from the
-                  underlying system, with the following considerations:
+                  <li>Ty to acquire position data from the underlying system,
+                  with the following considerations:
                     <ol>
                       <li>If |permission| is {{AccuracyMode/"approximate"}},
                       acquire an [=approximate position=]. The


### PR DESCRIPTION
Closes #182 

This PR is an alternate version of #195, introducing the ability for developers to request a less precise, privacy-preserving "approximate" location but without defining a separate powerful feature nor prescribing a specific permission model which distinguishes approximate and precise geolocation. In particular, while this PR is motivated by the [explainer](https://github.com/explainers-by-googlers/approximate-geolocation), it actually tries to follow and specify the proposed [WebKit model](https://github.com/w3c/geolocation/wiki/Approximate-Geolocation:-Permissions-Model-Comparison#webkit-model).

The following tasks have been completed:

 * [ ] Modified Web platform tests.

Implementation commitment (and no objections):

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=312748)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=394757795)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)

Documentation (new feature):

 * [ ] Updated implementation report
 * [ ] Pinged MDN
 * [x] Added example to README or spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/geolocation/pull/233.html" title="Last updated on Aug 5, 2026, 7:11 AM UTC (1bd58da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation/233/4aebf6e...antosart:1bd58da.html" title="Last updated on Aug 5, 2026, 7:11 AM UTC (1bd58da)">Diff</a>